### PR TITLE
Enable network access to JupyterHub API endpoint

### DIFF
--- a/notebooks-monitor/templates/deployment.yaml
+++ b/notebooks-monitor/templates/deployment.yaml
@@ -20,6 +20,7 @@ spec:
         app: hubmonitor
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+        hub.jupyter.org/network-access-hub: "true"
     spec:
       containers:
         - name: ui

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,4 +1,4 @@
-# Web front-end to monitor
+# Web frontend to monitor
 
 This is a simple flask application that takes a json file with the status and shows it when requested
 

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3-alpine
 
-RUN apk add --no-cache tini=0.19.0-r0
+RUN apk add --no-cache tini=0.19.0-r3
 
 COPY requirements.txt /
 
@@ -10,7 +10,7 @@ COPY monitor.py /
 
 ENV JUPYTERHUB_API_URL https://localhost/
 ENV JUPYTERHUB_API_TOKEN secret
-ENV JUPYTERHUB_API_USER monitoring 
+ENV JUPYTERHUB_API_USER monitoring
 ENV STATUS_FILE /status.json
 
 ENTRYPOINT ["/sbin/tini", "--"]

--- a/worker/README.md
+++ b/worker/README.md
@@ -20,7 +20,7 @@ And writes the result into a json file with this structure:
 
 The probe expects the following variables in the environment:
 - `JUPYTERHUB_API_URL`: URL where the JupyterHub API is found
-- `JUPYTERHUB_API_TOKEN`: token to authenticat against the API
+- `JUPYTERHUB_API_TOKEN`: token to authenticate against the API
 - `JUPYTERHUB_USER`: user to use for monitoring
 - `STATUS_FILE`: where to store the json with the result of monitoring (default: `status.json`)
 - `DEBUG`: when equal to `TRUE` will produce extra logging information


### PR DESCRIPTION
# Summary

Enable network access for monitoring to JupyterHub API endpoint.

Label "hub.jupyter.org/network-access-hub" is used for that in network policies in JupyterHub helm.

This is needed, when k8s network plugins like calico is used, which implement the policies. It has never been needed with weave.

---

<!-- Add, if any, the related issue here, e.g. #6 -->

**Related issue :**
